### PR TITLE
Add subpath for gpuNUFFT compilation

### DIFF
--- a/install.py
+++ b/install.py
@@ -96,7 +96,7 @@ if args.gpunufft:
     os.chdir(str(cwd) + "/gpuNUFFT/CUDA")
     subprocess.run(["mkdir", "-p", "build"])
     os.chdir(str(cwd) + "/gpuNUFFT/CUDA/build")
-    subprocess.run(["cmake", str(cwd), "-DGEN_MEX_FILES=OFF"])
+    subprocess.run(["cmake", str(cwd) + "/gpuNUFFT/CUDA", "-DGEN_MEX_FILES=OFF"])
     subprocess.run(["make"])
     os.chdir(str(cwd))
     cmake_args += ['-DWITH_GPUNUFFT=ON']


### PR DESCRIPTION
as otherwise not gpuNUFFTs CMakeList.txt is run but optox's instead.

Also gpuNUFFTs FindGPUNUFFT.cmake needs to be added to OptoX CMakeLists.txt's CMAKE_MODULE_PATH.

From GPUNUFFT_ROOT_DIR that's a static path.

 I'd add `f"-DGPUNUFFT_ROOT_DIR={os.path.join(str(cwd),'gpuNUFFT'}"`  to `cmake_args` and then in CMakeLists.txt `list(APPEND ${CMAKE_MODULE_PATH} "${GPUNUFFT_ROOT_DIR}/CUDA/cmake_modules")`, s.t. find_package doesn't error. 
 
 Will add that as commit as soon as I get gpuNUFFT to compile. (So please leave this open for now)